### PR TITLE
replace lodash.isnan with is-nan (65% size savings)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var isNaN = require('lodash.isnan');
+var isNaN = require('is-nan');
 
 module.exports = function (n) {
     var nInt = parseInt(n, 10);
@@ -19,6 +19,6 @@ module.exports = function (n) {
         while (rgx.test(x1)) {
             x1 = x1.replace(rgx, '$1' + ',' + '$2');
         }
-        return x1 + x2; 
+        return x1 + x2;
     }
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "mocha": "^1.19.0"
   },
   "dependencies": {
-    "lodash.isnan": "^2.4.1"
+    "is-nan": "^1.0.1"
   }
 }


### PR DESCRIPTION
This reduces this module’s size by 65%. 3.6KB -> 1.2KB

``` bash
browserify ./ | wc -c
    3634
```

``` bash
browserify ./ | wc -c
    1291
```
